### PR TITLE
Ignore custom git diff formatting in gitconfig

### DIFF
--- a/git-autofixup
+++ b/git-autofixup
@@ -335,7 +335,7 @@ sub blame {
 
 sub get_diff_hunks {
     my $num_context_lines = shift;
-    my @cmd = (qw(git diff --ignore-submodules), "-U$num_context_lines");
+    my @cmd = (qw(git -c diff.noprefix=false diff --ignore-submodules), "-U$num_context_lines");
     open(my $fh, '-|', @cmd) or die $!;
     my @hunks = parse_hunks($fh, keep_lines => 1);
     close($fh) or die "git diff: non-zero exit code";

--- a/t/autofixup.t
+++ b/t/autofixup.t
@@ -168,7 +168,7 @@ sub write_file {
 
 sub get_git_log {
     my $revision = shift;
-    my $log = qx{git log -p --format=%s ${revision}..};
+    my $log = qx{git -c diff.noprefix=false log -p --format=%s ${revision}..};
     if ($? != 0) {
         croak "git log: $?\n";
     }


### PR DESCRIPTION
Or at least `diff.noprefix=true`, there are possibly other options that could break things...

Fixes #10.