### PR TITLE
Create each fixup commit only once

### DIFF
--- a/git-autofixup
+++ b/git-autofixup
@@ -422,12 +422,14 @@ sub ordered_shas {
     my $hunks_for = shift;
     my $nsha = scalar keys %{$hunks_for};
     my @ordered = ();
+    my %have = ();
     for my $tgt (@{$hunks}) {
         last if (@ordered >= $nsha);
-        for my $sha (keys %{$hunks_for}) {
+        for my $sha (grep {!$have{$_}} keys %{$hunks_for}) {
             my $sha_hunks = $hunks_for->{$sha};
             if (grep {$_->{file} eq $tgt->{file} && $_->{start} == $tgt->{start}} @{$sha_hunks}) {
                 push @ordered, $sha;
+                $have{$sha} = 1;
                 last;
             }
         }

--- a/t/autofixup.t
+++ b/t/autofixup.t
@@ -13,7 +13,7 @@ if ($OSNAME eq 'MSWin32') {
 } elsif (!has_git()) {
     plan skip_all => 'git version 1.7.4+ required'
 } else {
-    plan tests => 37;
+    plan tests => 38;
 }
 
 require './git-autofixup';
@@ -583,4 +583,41 @@ index c9c6af7..e6bfff5 100644
 @@ -1 +1 @@
 -b1
 +b2
+}});
+
+test_autofixup({
+    name => "multiple hunks to the same commit",
+    topic_commits => [
+        {a => "a1.0\na2\na3\na4\na5\na6\na7\na8\na9.0\n"},
+        {b => "b1.0\n"},
+    ],
+    unstaged => {'a' =>  "a1.1\na2\na3\na4\na5\na6\na7\na8\na9.1\n", b => "b1.1\n"},
+    exit_code => 0,
+    log_want => q{fixup! commit1
+
+diff --git a/b b/b
+index 253a619..6419a9e 100644
+--- a/b
++++ b/b
+@@ -1 +1 @@
+-b1.0
++b1.1
+fixup! commit0
+
+diff --git a/a b/a
+index 5d11004..0054137 100644
+--- a/a
++++ b/a
+@@ -1,4 +1,4 @@
+-a1.0
++a1.1
+ a2
+ a3
+ a4
+@@ -6,4 +6,4 @@ a5
+ a6
+ a7
+ a8
+-a9.0
++a9.1
 }});


### PR DESCRIPTION
When two hunks belong to the same commit, this fixup target commit can
occur twice in the commit list returned by ordered_shas.  In that case,
git-autofixup tries to commit the same changes twice.

Here is a simple reproducer:

	git init tmp_repo
	cd tmp_repo
	git commit --allow-empty -m initial\ commit

	seq 1 20 > a
	git add a
	git commit -m A

	seq 1 10 > b
	git add b
	git commit -m B

	sed -i -e 2cX -e 18cX a
	sed -i -e 2cX b
	../git-autofixup HEAD~2

git-autofixup HEAD~2 before the fix:

	master 2b1471a] fixup! A
	 1 file changed, 2 insertions(+), 2 deletions(-)
	error: patch failed: a:1
	error: a: patch does not apply
	error: patch failed: a:15
	error: a: patch does not apply
	git apply: non-zero exit code

git-autofixup HEAD~2 after the fix:

	[master b7e0124] fixup! A
	 1 file changed, 2 insertions(+), 2 deletions(-)
	[master 1810461] fixup! B
	 1 file changed, 1 insertion(+), 1 deletion(-)